### PR TITLE
Fix possible double / in url.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,10 +87,10 @@ function urlPathJoin(...paths: string[]): string {
     if (i > 0) {
       path = path.replace(/\/\/+/, '/');
     }
-    if (url.length > 0 && url.charAt(url.length - 1) != '/') {
-      url = url + '/' + paths[i];
+    if (url.length > 0 && url.charAt(url.length - 1) != '/' && path[0] != '/') {
+      url = url + '/' + path;
     } else {
-      url = url + paths[i];
+      url = url + path;
     }
   }
   return url


### PR DESCRIPTION
The function could return a double / under some condition. This broke the JupyterLab cookies in my setup (cookie set to /user/laurent, websocket query to //user/laurent).
Also, path is modified using a regex on line 88 and later, paths[i] was used instead of the modified path.
